### PR TITLE
Arrumando cor de foco dos nav links

### DIFF
--- a/src/views/pages/elements/css/header.css
+++ b/src/views/pages/elements/css/header.css
@@ -50,6 +50,10 @@
   color: #9E829C;
 }
 
+.nav-link:focus {
+  color: #9E829C;
+}
+
 .navbar-toggler {
   background-color: #9E829C;
 }


### PR DESCRIPTION
A cor estava preta ao clicar e estava dando a impressão de que o nav link sumia.